### PR TITLE
Add licensing section and guide to resources.md

### DIFF
--- a/resources/resources.md
+++ b/resources/resources.md
@@ -63,6 +63,9 @@
 * [jake vdp example pr](https://www.youtube.com/watch?v=rgbCcBNZcdQ)
 * [Blog post](http://www.hanselman.com/blog/GetInvolvedInOpenSourceTodayHowToContributeAPatchToAGitHubHostedOpenSourceProjectLikeCode52.aspx) detailing a simple PR to a markdown reader
 
+### Licensing
+* [Developer’s Guide to Open Source Licenses](https://www.toptal.com/open-source/developers-guide-to-open-source-licenses)
+
 ## Ideas
 * clean up harsh English in READMEs
 * [awesome-beginners](https://github.com/MunGell/awesome-for-beginners)


### PR DESCRIPTION
Given the importance of licensing when dealing with open-source software, I added a 'licensing' section to `resources.md`. I also added a link to [this](https://www.toptal.com/open-source/developers-guide-to-open-source-licenses) helpful guide between the various open-source software licenses.