### PR TITLE
fix typo in 'git push' definition

### DIFF
--- a/git.html
+++ b/git.html
@@ -94,7 +94,7 @@
           </li>
 
           <li>
-            <a href="https://git-scm.com/docs/git-push"><code>git push</code></a>: Updates the references (<code>HEAD</code>, <code>master</code>, etc.) on the remote using local references. It sends objects the are present locally but not remotely in order to bring the remote up to date with your local copy.
+            <a href="https://git-scm.com/docs/git-push"><code>git push</code></a>: Updates the references (<code>HEAD</code>, <code>master</code>, etc.) on the remote using local references. It sends objects that are present locally but not remotely in order to bring the remote up to date with your local copy.
             <img src="git_cheatsheet/img/git_push.png" />
           </li>
   


### PR DESCRIPTION
Git push definition had a typo (that -> the)