### PR TITLE
Integrated New style. And fixed a few small bugs. 

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -216,7 +216,7 @@ main section ul li {
 }
 
 main ul li a:first-of-type {
-  text-decoration: none;
+  text-decoration: underline;
   display: block;
   margin-bottom: 20px;
   font-size: 15px;

--- a/assignments.html
+++ b/assignments.html
@@ -20,6 +20,8 @@
             <a href='assignments.html'>Assignments</a>
             <a href='resources.html'>Resources</a>
             <a href='git.html'>Git Cheatsheet</a>
+            <a href='essays.html'>Essays</a>
+            <a href="projects.html">Projects</a>
             <a href='https://github.com/nzufelt/open_source_movement_csc630/' class='right'>On GitHub</a>
           </nav>
         </div>

--- a/essays.html
+++ b/essays.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" >
     <title>CSC630: The Open Source Movement</title>
-    <link rel="stylesheet" type="text/css" href="stylesheet.css" />
+    <link rel="stylesheet" type="text/css" href='./assets/styles/main.css' />
     <meta name="description" content="CSC630: The Open Source Movement, Phillips Academy Andover, Winter 2018"/>
     <meta name="keywords" content="computer science, open source" />
     <meta name="robots" content="index,follow" />
@@ -11,16 +11,21 @@
 <body>
 <div id="container">
   <header>
-    <h1>The Open Source Movement</h1>
-    <h3>Resources</h3>
+    <div class='gradient'></div>
+    <div class='content'>
+      <h1><a href='index.html'>CSC630: The Open Source Movement</a> // Assignments <span class='right'><p>Phillips Academy Andover &emsp;&#x25AA;&emsp; Winter 2018</p></span></h1>
+    </div>
+    <div class='nav-wrapper'>
+      <nav>
+        <a href='assignments.html'>Assignments</a>
+        <a href='resources.html'>Resources</a>
+        <a href='git.html'>Git Cheatsheet</a>
+        <a href='essays.html'>Essays</a>
+        <a href="projects.html">Projects</a>
+        <a href='https://github.com/nzufelt/open_source_movement_csc630/' class='right'>On GitHub</a>
+      </nav>
+    </div>
   </header>
-  <nav>
-    <a href="resources.html">Resources</a>
-    <a href="assignments.html">Assignments</a>
-    <a href="git.html">git cheatsheet</a>
-    <a href="essays.html">Essays</a>
-    <a href="projects.html">Projects</a>
-  </nav>
   <main id="content">
     <section id="section1">
       <article>

--- a/git.html
+++ b/git.html
@@ -13,13 +13,15 @@
       <header>
         <div class='gradient'></div>
         <div class='content'>
-          <h1><a href='index.html'>CSC630: The Open Source Movement</a> // Git Cheatsheet <span class='right'><p>Phillips Academy Andover &emsp;&#x25AA;&emsp; Winter 2018</p></span></h1>
+          <h1><a href='index.html'>CSC630: The Open Source Movement</a> // Assignments <span class='right'><p>Phillips Academy Andover &emsp;&#x25AA;&emsp; Winter 2018</p></span></h1>
         </div>
         <div class='nav-wrapper'>
           <nav>
             <a href='assignments.html'>Assignments</a>
             <a href='resources.html'>Resources</a>
             <a href='git.html'>Git Cheatsheet</a>
+            <a href='essays.html'>Essays</a>
+            <a href="projects.html">Projects</a>
             <a href='https://github.com/nzufelt/open_source_movement_csc630/' class='right'>On GitHub</a>
           </nav>
         </div>

--- a/projects.html
+++ b/projects.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" >
     <title>CSC630: The Open Source Movement</title>
-    <link rel="stylesheet" type="text/css" href="stylesheet.css" />
+    <link rel='stylesheet' type='text/css' href='./assets/styles/main.css' />
     <meta name="description" content="CSC630: The Open Source Movement, Phillips Academy Andover, Winter 2018"/>
     <meta name="keywords" content="computer science, open source" />
     <meta name="robots" content="index,follow" />
@@ -11,16 +11,21 @@
 <body>
 <div id="container">
   <header>
-    <h1>The Open Source Movement</h1>
-    <h3>Resources</h3>
+    <div class='gradient'></div>
+    <div class='content'>
+      <h1><a href='index.html'>CSC630: The Open Source Movement</a> // Assignments <span class='right'><p>Phillips Academy Andover &emsp;&#x25AA;&emsp; Winter 2018</p></span></h1>
+    </div>
+    <div class='nav-wrapper'>
+      <nav>
+        <a href='assignments.html'>Assignments</a>
+        <a href='resources.html'>Resources</a>
+        <a href='git.html'>Git Cheatsheet</a>
+        <a href='essays.html'>Essays</a>
+        <a href="projects.html">Projects</a>
+        <a href='https://github.com/nzufelt/open_source_movement_csc630/' class='right'>On GitHub</a>
+      </nav>
+    </div>
   </header>
-  <nav>
-    <a href="resources.html">Resources</a>
-    <a href="assignments.html">Assignments</a>
-    <a href="git.html">git cheatsheet</a>
-    <a href="essays.html">Essays</a>
-    <a href="projects.html">Projects</a>
-  </nav>
   <main id="content">
     <section id="section1">
       <article>

--- a/resources.html
+++ b/resources.html
@@ -17,9 +17,11 @@
         </div>
         <div class='nav-wrapper'>
           <nav>
-            <a href='resources.html'>Resources</a>
             <a href='assignments.html'>Assignments</a>
+            <a href='resources.html'>Resources</a>
             <a href='git.html'>Git Cheatsheet</a>
+            <a href='essays.html'>Essays</a>
+            <a href="projects.html">Projects</a>
             <a href='https://github.com/nzufelt/open_source_movement_csc630/' class='right'>On GitHub</a>
           </nav>
         </div>


### PR DESCRIPTION
Integrated Rudd's CSS to the Essays and Projects pages. Added the headers from the rest of the pages to essays and projects. 
All of the pages were missing section headers to the two new pages (essays and projects); I added those. On resources.html the section headers were out of order—resources was first instead of second. 
The links on our website had no distinction showing that they were links. Added underline text-decoration links of the resource page. 