### PR TITLE
Add essay to `essays` page

### DIFF
--- a/essays.html
+++ b/essays.html
@@ -34,6 +34,15 @@
         </p>
       </article>
     </section>
+    <section>
+      <article>
+        <p>
+          <a href="https://milesmcc.github.io/OpenSourceLaw/PAPER.html">Licenses, Loopholes, and Litigation: a Comprehensive Survey of Software Case Law and Open Source Licensing in the United States</a>
+          <br>
+          <i>by <a href="https://rmrm.io">Miles McCain</a></i>
+        </p>
+      </article>
+    </section>
   </main>
   <footer>
   </footer>


### PR DESCRIPTION
This pull requests adds my essay, [`Licenses, Loopholes, and Litigation: a Comprehensive Survey of Software Case Law and Open Source Licensing in the United States`](https://milesmcc.github.io/OpenSourceLaw/PAPER.html), to the `Essays` page.

With this change, the page will look like the following:
![screenshot-2018-1-18 csc630 the open source movement](https://user-images.githubusercontent.com/3037552/35131420-171c81da-fc94-11e7-8b5b-340cfdf9d799.png)
