### PR TITLE
Add `DS_Store` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
This pull requests adds the file `.DS_Store` to `.gitignore` so that Mac users won't accidentally upload the hidden file.

Satisfies the request of @ksun0 in https://github.com/nzufelt/open_source_movement_csc630/pull/49.