### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Open Source Movement
 
-This repo holds all the publically available content for the Honors Computer Science Seminar at Phillips Academy Andover, CSC630: The Open Source Movement.
+This repo holds all the publicly available content for the Honors Computer Science Seminar at Phillips Academy Andover, CSC630: The Open Source Movement.
 
 ## Contributing
 

--- a/essays.html
+++ b/essays.html
@@ -1,45 +1,47 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta charset="utf-8" >
-    <title>CSC630: The Open Source Movement</title>
-    <link rel="stylesheet" type="text/css" href='./assets/styles/main.css' />
-    <meta name="description" content="CSC630: The Open Source Movement, Phillips Academy Andover, Winter 2018"/>
-    <meta name="keywords" content="computer science, open source" />
-    <meta name="robots" content="index,follow" />
+  <meta charset="utf-8" >
+  <title>CSC630: The Open Source Movement</title>
+  <link rel="stylesheet" type="text/css" href='./assets/styles/main.css' />
+  <meta name="description" content="CSC630: The Open Source Movement, Phillips Academy Andover, Winter 2018"/>
+  <meta name="keywords" content="computer science, open source" />
+  <meta name="robots" content="index,follow" />
 </head>
 <body>
-<div id="container">
-  <header>
-    <div class='gradient'></div>
-    <div class='content'>
-      <h1><a href='index.html'>CSC630: The Open Source Movement</a> // Assignments <span class='right'><p>Phillips Academy Andover &emsp;&#x25AA;&emsp; Winter 2018</p></span></h1>
-    </div>
-    <div class='nav-wrapper'>
-      <nav>
-        <a href='assignments.html'>Assignments</a>
-        <a href='resources.html'>Resources</a>
-        <a href='git.html'>Git Cheatsheet</a>
-        <a href='essays.html'>Essays</a>
-        <a href="projects.html">Projects</a>
-        <a href='https://github.com/nzufelt/open_source_movement_csc630/' class='right'>On GitHub</a>
-      </nav>
-    </div>
-  </header>
-  <main id="content">
-    <section id="section1">
-      <article>
-        <p>
-          A collection of essays written by students in this class. To be updated once said essays have been written.
-        </p>
-      </article>
-    </section>
-  </main>
-  <footer>
-  </footer>
+  <div id="container">
+    <header>
+      <div class='gradient'></div>
+      <div class='content'>
+        <h1><a href='index.html'>CSC630: The Open Source Movement</a> // Assignments <span class='right'><p>Phillips Academy Andover &emsp;&#x25AA;&emsp; Winter 2018</p></span></h1>
+      </div>
+      <div class='nav-wrapper'>
+        <nav>
+          <a href='assignments.html'>Assignments</a>
+          <a href='resources.html'>Resources</a>
+          <a href='git.html'>Git Cheatsheet</a>
+          <a href='essays.html'>Essays</a>
+          <a href="projects.html">Projects</a>
+          <a href='https://github.com/nzufelt/open_source_movement_csc630/' class='right'>On GitHub</a>
+        </nav>
+      </div>
+    </header>
+    <main id="content">
+      <section>
+        <article>
+          <p>
+            <a href="https://drive.google.com/file/d/1BiVGIhFp1Xdc6PlFFtOhW5pPc-bncrZG/view" target="_blank">An Assist for Assistive Technology: The Role of the Open Source Movement in the Advancement of Assistive Technology</a>
+            <br>
+            Kabir A Nagral
+          </p>
+        </article>
+      </section>
+          </main>
+          <footer>
+          </footer>
 
-</div>
-<script src="scripts.js">
-</script>
-</body>
-</html>
+        </div>
+        <script src="scripts.js">
+        </script>
+      </body>
+      </html>


### PR DESCRIPTION
I fixed a typo in README.md — `publicly` was incorrectly spelled `publically` — that was initially corrected by @malcolmessaid in #31. 